### PR TITLE
Update to v0.6.0

### DIFF
--- a/me.drewol.Unnamed-SDVX-Clone.metainfo.xml
+++ b/me.drewol.Unnamed-SDVX-Clone.metainfo.xml
@@ -47,6 +47,9 @@
   </developer>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="0.6.0" date="2024-06-21">
+      <description>https://github.com/Drewol/unnamed-sdvx-clone/releases/tag/v0.6.0</description>
+    </release>
     <release version="0.5.0" date="2021-06-13">
       <description>https://github.com/Drewol/unnamed-sdvx-clone/releases/tag/v0.5.0</description>
     </release>

--- a/me.drewol.Unnamed-SDVX-Clone.metainfo.xml
+++ b/me.drewol.Unnamed-SDVX-Clone.metainfo.xml
@@ -48,10 +48,20 @@
   <content_rating type="oars-1.1"/>
   <releases>
     <release version="0.6.0" date="2024-06-21">
-      <description>https://github.com/Drewol/unnamed-sdvx-clone/releases/tag/v0.6.0</description>
+      <description>
+        <p>
+          For full release notes, see the releases page on Github.
+        </p>
+      </description>
+      <url>https://github.com/Drewol/unnamed-sdvx-clone/releases/tag/v0.6.0</url>
     </release>
     <release version="0.5.0" date="2021-06-13">
-      <description>https://github.com/Drewol/unnamed-sdvx-clone/releases/tag/v0.5.0</description>
+      <description>
+        <p>
+          For full release notes, see the releases page on Github.
+        </p>
+      </description>
+      <url>https://github.com/Drewol/unnamed-sdvx-clone/releases/tag/v0.5.0</url>
     </release>
   </releases>
 </component>

--- a/me.drewol.Unnamed-SDVX-Clone.yml
+++ b/me.drewol.Unnamed-SDVX-Clone.yml
@@ -31,7 +31,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/Drewol/unnamed-sdvx-clone.git
-        commit: f264d380dd0550a781237028392e68db1ec51478
+        tag: v0.6.0
       - type: file
         path: me.drewol.Unnamed-SDVX-Clone.metainfo.xml
       - type: archive


### PR DESCRIPTION
Fixes #1 

This version introduces vcpkg, I'm not sure if I need to do anything special for sandboxed builds to work

deps here: https://github.com/Drewol/unnamed-sdvx-clone/blob/v0.6.0/vcpkg.json